### PR TITLE
feat: export csv shows

### DIFF
--- a/src/core/serializer/toCsv.test.ts
+++ b/src/core/serializer/toCsv.test.ts
@@ -29,9 +29,11 @@ describe("toCsv", () => {
     });
 
     it.only("should serialize shows", () => {
+        const shows = [chernobyl_up_to_date, house_usher_continuing];
+
         const result = toCsv({
             movies: [],
-            shows: [chernobyl_up_to_date, house_usher_continuing] as any,
+            shows: shows as any,
         });
 
         expect(result).toBeString();
@@ -53,9 +55,12 @@ describe("toCsv", () => {
                                 watched_at,
                             },
                         ) => {
+                            if (!is_watched) {
+                                return;
+                            }
                             const row = rest.shift();
                             expect(row).toBe(
-                                `${id?.imdb},${id?.tvdb},show,${chernobyl_up_to_date.title},${season},${episode},${special},${is_watched},${watched_at},${chernobyl_up_to_date.status},false\r`,
+                                `${id?.imdb},${id?.tvdb},episode,${chernobyl_up_to_date.title},${season},${episode},${special},${is_watched},${watched_at},${chernobyl_up_to_date.status},false\r`,
                             );
                         },
                     );
@@ -74,14 +79,33 @@ describe("toCsv", () => {
                                 watched_at,
                             },
                         ) => {
+                            if (!is_watched) {
+                                return;
+                            }
                             const row = rest.shift();
                             expect(row).toBe(
-                                `${id?.imdb},${id?.tvdb},show,${house_usher_continuing.title},${season},${episode},${special},${is_watched},${
+                                `${id?.imdb},${id?.tvdb},episode,${house_usher_continuing.title},${season},${episode},${special},${is_watched},${
                                     watched_at ?? ""
                                 },${house_usher_continuing.status},${watched_at == null}\r`,
                             );
                         },
                     );
             });
+
+        shows.forEach(({
+            id,
+            title,
+            status,
+            seasons,
+        }) => {
+            const hasUnwatchedEpisode = seasons?.some(
+                ({ episodes }) => episodes.some(episode => !episode.is_watched)
+            );
+
+            const row = rest.shift();
+            expect(row).toBe(
+                `${id?.imdb},${id?.tvdb},show,${title},,,,,,${status},${hasUnwatchedEpisode}\r`,
+            );
+        })
     });
 });

--- a/src/core/serializer/toCsv.ts
+++ b/src/core/serializer/toCsv.ts
@@ -44,7 +44,7 @@ export function toCsv({
             watched_at == null,
         ]);
 
-    const showCsvEntries = shows
+    const episodesCsvEntries = shows
         .flatMap(({
             title,
             seasons,
@@ -55,6 +55,7 @@ export function toCsv({
                 episodes,
             }) =>
                 episodes
+                    .filter(episode => episode.is_watched)
                     .map(({
                         id,
                         special,
@@ -64,7 +65,7 @@ export function toCsv({
                     }) => [
                         id?.imdb,
                         id?.tvdb,
-                        "show",
+                        "episode",
                         title,
                         season,
                         episode,
@@ -77,9 +78,36 @@ export function toCsv({
             )
         );
 
+    const showCsvEntries = shows
+        .flatMap(({
+            id: showId,
+            title,
+            seasons,
+            status,
+        }) => {
+            const hasUnwatchedEpisode = seasons?.some(
+                ({ episodes }) => episodes.some(episode => !episode.is_watched)
+            );
+
+            return [[
+                showId?.imdb,
+                showId?.tvdb,
+                "show",
+                title,
+                "",
+                "",
+                "",
+                "",
+                "",
+                status,
+                hasUnwatchedEpisode,
+            ]]
+        });
+
     return stringify([
         header,
         ...movieCsvEntries,
+        ...episodesCsvEntries,
         ...showCsvEntries,
     ]);
 }


### PR DESCRIPTION
## 🎶 Notes 🎶

When flattening to csv, episodes and shows are split up
- In case of episodes: only episodes that are watched are added to the csv with type `episode`
- In case of all shows: all shows are added to the csv with type `show`
  - If a show has any unwatched episodes, it's marked as `is_watchlisted` 
- We can leave the id fields as is, since the type will be the discerning factor