### PR TITLE
ci / define cws publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "latest"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Update package.json with tag version
+        working-directory: src/extension
+        run: |
+          TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
+          if [[ ! $TAG =~ ^(?:\d{1,5}\.){0,3}\d{1,5}$ ]]; then
+            echo "Tag $TAG does not match the required pattern"
+            exit 1
+          fi
+          TAG=$(echo $TAG | sed 's/^v//')
+          echo "Updating package.json with version $TAG"
+          jq --arg tag "$TAG" '.version = $tag' package.json > tmp.$$.json && mv tmp.$$.json package.json
+
+      - name: Build extension
+        run: bun extension:build
+
+      - name: Archive extension
+        run: zip -r tv-time-liberator.zip src/extension/dist
+
+      - name: Upload to Chrome Web Store
+        uses: mobilefirstllc/cws-publish@latest
+        with:
+          action: "upload"
+          client_id: ${{ secrets.GOOGLE_CLIENT }}
+          client_secret: ${{ secrets.GOOGLE_SECRET }}
+          refresh_token: ${{ secrets.GOOGLE_REFRESH_TOKEN}}
+          extension_id: ${{ secrets.CWS_EXTENSION_ID }}
+          zip_file: "tv-time-liberator.zip"

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -2,7 +2,7 @@
   "name": "tv-time-liberator-extension",
   "description": "Easily export your watch history, favorites, and lists from TV Time. Perfect for backup, migration, or analysis.",
   "private": true,
-  "version": "1.1.2",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
This pull request, a beacon of automation in the desolate wasteland of manual labor, unveils a new GitHub Actions workflow for publishing the extension, freeing us from the shackles of tedious repetition. Observe, with a weary sigh of relief, the emergence of `publish.yml` and the dynamic versioning sorcery within `package.json`.

### New GitHub Actions Workflow (or, "The Automation Conjuration"):

* The `publish.yml` workflow materializes from the depths of the `.github/workflows` directory, a digital incantation designed to banish the drudgery of manual publishing. This automated ritual, triggered by the mystical act of tag pushing, installs dependencies, mutates the `package.json` version with arcane precision, constructs the extension with machine-like efficiency, entombs it within an archive, and finally, hurls it into the vast expanse of the Chrome Web Store.

### Package Version Management (or, "The Versioning Voodoo"):

* The `package.json` file, once a static repository of version information, now embraces the ephemeral nature of change, its version set to the enigmatic `0.0.0`. This seemingly insignificant placeholder, a vessel for dynamic transformation, awaits the touch of the new workflow, its true version revealed only at the moment of publishing, like a prophecy fulfilled.

These changes, a testament to our relentless pursuit of efficiency and automation, mark a significant step towards a world where manual labor is a distant memory, a relic of a bygone era. The `publish.yml` workflow, a tireless digital automaton, stands ready to shoulder the burden of extension publishing, freeing us to focus on more pressing matters, like contemplating the existential dread of an ever-expanding codebase.
