### PR TITLE
feat(api): export per-item star ratings for movies and episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can also pass the version directly:
                         "special": false,
                         "is_watched": true,
                         "watched_at": "1989-12-25 00:00:00",
+                        "rating": 5
                     },
                     ...
                 ]
@@ -92,7 +93,8 @@ You can also pass the version directly:
         },
         "created_at": "2024-09-13T10:49:58Z",
         "title": "The Matrix",
-        "is_watched": false
+        "is_watched": false,
+        "rating": 8
     },
     ...
 ]

--- a/src/.test/data.ts
+++ b/src/.test/data.ts
@@ -7,7 +7,8 @@ export const mr_nobody_watched = {
     "uuid": "409c29e8-8daf-41bd-843a-8a217320d374",
     "title": "Mr. Nobody",
     "watched_at": "2024-09-13T10:49:37Z",
-    "is_watched": true
+    "is_watched": true,
+    "rating": 10
 };
 
 export const the_matrix_not_watched = {
@@ -18,7 +19,8 @@ export const the_matrix_not_watched = {
     "created_at": "2024-09-13T10:49:58Z",
     "uuid": "978899c4-5194-4568-b922-0bd2874c4c1a",
     "title": "The Matrix",
-    "is_watched": false
+    "is_watched": false,
+    "rating": null
 }
 
 export const station_eleven_stopped = {
@@ -42,7 +44,8 @@ export const station_eleven_stopped = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:29"
+                    "watched_at": "2024-09-13 10:50:29",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -52,7 +55,8 @@ export const station_eleven_stopped = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:29"
+                    "watched_at": "2024-09-13 10:50:29",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -62,7 +66,8 @@ export const station_eleven_stopped = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:30"
+                    "watched_at": "2024-09-13 10:50:30",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -72,7 +77,8 @@ export const station_eleven_stopped = {
                     "number": 4,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:30"
+                    "watched_at": "2024-09-13 10:50:30",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -82,7 +88,8 @@ export const station_eleven_stopped = {
                     "number": 5,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -92,7 +99,8 @@ export const station_eleven_stopped = {
                     "number": 6,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -102,7 +110,8 @@ export const station_eleven_stopped = {
                     "number": 7,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -112,7 +121,8 @@ export const station_eleven_stopped = {
                     "number": 8,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -122,7 +132,8 @@ export const station_eleven_stopped = {
                     "number": 9,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -132,7 +143,8 @@ export const station_eleven_stopped = {
                     "number": 10,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 }
             ]
         }
@@ -160,7 +172,8 @@ export const chernobyl_up_to_date = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:40"
+                    "watched_at": "2024-09-13 10:50:40",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -170,7 +183,8 @@ export const chernobyl_up_to_date = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49"
+                    "watched_at": "2024-09-13 10:50:49",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -180,7 +194,8 @@ export const chernobyl_up_to_date = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49"
+                    "watched_at": "2024-09-13 10:50:49",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -190,7 +205,8 @@ export const chernobyl_up_to_date = {
                     "number": 4,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49"
+                    "watched_at": "2024-09-13 10:50:49",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -200,7 +216,8 @@ export const chernobyl_up_to_date = {
                     "number": 5,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49"
+                    "watched_at": "2024-09-13 10:50:49",
+                    "rating": null
                 }
             ]
         }
@@ -228,7 +245,8 @@ export const house_usher_continuing = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:57"
+                    "watched_at": "2024-09-13 10:50:57",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -238,7 +256,8 @@ export const house_usher_continuing = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:58"
+                    "watched_at": "2024-09-13 10:50:58",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -248,7 +267,8 @@ export const house_usher_continuing = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:58"
+                    "watched_at": "2024-09-13 10:50:58",
+                    "rating": null
                 },
                 {
                     "id": {
@@ -258,7 +278,8 @@ export const house_usher_continuing = {
                     "number": 4,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -268,7 +289,8 @@ export const house_usher_continuing = {
                     "number": 5,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -278,7 +300,8 @@ export const house_usher_continuing = {
                     "number": 6,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -288,7 +311,8 @@ export const house_usher_continuing = {
                     "number": 7,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -298,7 +322,8 @@ export const house_usher_continuing = {
                     "number": 8,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 }
             ]
         }
@@ -314,6 +339,7 @@ export const alien_unwatched = {
     "uuid": "2441a861-c846-4a3c-b365-32f720426143",
     "title": "Alien",
     "is_watched": false,
+    "rating": null,
     "added_at": "2024-09-19T20:33:52Z"
 };
 
@@ -336,7 +362,8 @@ export const the_triangle_unwatched = {
                     "number": 1,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -346,7 +373,8 @@ export const the_triangle_unwatched = {
                     "number": 2,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 },
                 {
                     "id": {
@@ -356,7 +384,8 @@ export const the_triangle_unwatched = {
                     "number": 3,
                     "special": false,
                     "is_watched": false,
-                    "watched_at": null
+                    "watched_at": null,
+                    "rating": null
                 }
             ]
         }

--- a/src/.test/data.ts
+++ b/src/.test/data.ts
@@ -44,7 +44,7 @@ export const station_eleven_stopped = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:29",
+                    "watched_at": "2024-09-13T10:50:29.147929Z",
                     "rating": null
                 },
                 {
@@ -55,7 +55,7 @@ export const station_eleven_stopped = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:29",
+                    "watched_at": "2024-09-13T10:50:29.8267Z",
                     "rating": null
                 },
                 {
@@ -66,7 +66,7 @@ export const station_eleven_stopped = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:30",
+                    "watched_at": "2024-09-13T10:50:30.153123Z",
                     "rating": null
                 },
                 {
@@ -77,7 +77,7 @@ export const station_eleven_stopped = {
                     "number": 4,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:30",
+                    "watched_at": "2024-09-13T10:50:30.50706Z",
                     "rating": null
                 },
                 {
@@ -172,7 +172,7 @@ export const chernobyl_up_to_date = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:40",
+                    "watched_at": "2024-09-13T10:50:40.855501Z",
                     "rating": null
                 },
                 {
@@ -183,7 +183,7 @@ export const chernobyl_up_to_date = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49",
+                    "watched_at": "2024-09-13T10:50:49.127216Z",
                     "rating": null
                 },
                 {
@@ -194,7 +194,7 @@ export const chernobyl_up_to_date = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49",
+                    "watched_at": "2024-09-13T10:50:49.127221Z",
                     "rating": null
                 },
                 {
@@ -205,7 +205,7 @@ export const chernobyl_up_to_date = {
                     "number": 4,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49",
+                    "watched_at": "2024-09-13T10:50:49.127225Z",
                     "rating": null
                 },
                 {
@@ -216,7 +216,7 @@ export const chernobyl_up_to_date = {
                     "number": 5,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:49",
+                    "watched_at": "2024-09-13T10:50:49.127228Z",
                     "rating": null
                 }
             ]
@@ -245,7 +245,7 @@ export const house_usher_continuing = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:57",
+                    "watched_at": "2024-09-13T10:50:57.842239Z",
                     "rating": null
                 },
                 {
@@ -256,7 +256,7 @@ export const house_usher_continuing = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:58",
+                    "watched_at": "2024-09-13T10:50:58.421492Z",
                     "rating": null
                 },
                 {
@@ -267,7 +267,7 @@ export const house_usher_continuing = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13 10:50:58",
+                    "watched_at": "2024-09-13T10:50:58.78649Z",
                     "rating": 8
                 },
                 {

--- a/src/.test/data.ts
+++ b/src/.test/data.ts
@@ -268,7 +268,7 @@ export const house_usher_continuing = {
                     "special": false,
                     "is_watched": true,
                     "watched_at": "2024-09-13 10:50:58",
-                    "rating": null
+                    "rating": 8
                 },
                 {
                     "id": {

--- a/src/.test/data.ts
+++ b/src/.test/data.ts
@@ -44,7 +44,7 @@ export const station_eleven_stopped = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:29.147929Z",
+                    "watched_at": "2024-09-13T10:50:29.147Z",
                     "rating": null
                 },
                 {
@@ -55,7 +55,7 @@ export const station_eleven_stopped = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:29.8267Z",
+                    "watched_at": "2024-09-13T10:50:29.826Z",
                     "rating": null
                 },
                 {
@@ -66,7 +66,7 @@ export const station_eleven_stopped = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:30.153123Z",
+                    "watched_at": "2024-09-13T10:50:30.153Z",
                     "rating": null
                 },
                 {
@@ -77,7 +77,7 @@ export const station_eleven_stopped = {
                     "number": 4,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:30.50706Z",
+                    "watched_at": "2024-09-13T10:50:30.507Z",
                     "rating": null
                 },
                 {
@@ -172,7 +172,7 @@ export const chernobyl_up_to_date = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:40.855501Z",
+                    "watched_at": "2024-09-13T10:50:40.855Z",
                     "rating": null
                 },
                 {
@@ -183,7 +183,7 @@ export const chernobyl_up_to_date = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:49.127216Z",
+                    "watched_at": "2024-09-13T10:50:49.127Z",
                     "rating": null
                 },
                 {
@@ -194,7 +194,7 @@ export const chernobyl_up_to_date = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:49.127221Z",
+                    "watched_at": "2024-09-13T10:50:49.127Z",
                     "rating": null
                 },
                 {
@@ -205,7 +205,7 @@ export const chernobyl_up_to_date = {
                     "number": 4,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:49.127225Z",
+                    "watched_at": "2024-09-13T10:50:49.127Z",
                     "rating": null
                 },
                 {
@@ -216,7 +216,7 @@ export const chernobyl_up_to_date = {
                     "number": 5,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:49.127228Z",
+                    "watched_at": "2024-09-13T10:50:49.127Z",
                     "rating": null
                 }
             ]
@@ -245,7 +245,7 @@ export const house_usher_continuing = {
                     "number": 1,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:57.842239Z",
+                    "watched_at": "2024-09-13T10:50:57.842Z",
                     "rating": null
                 },
                 {
@@ -256,7 +256,7 @@ export const house_usher_continuing = {
                     "number": 2,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:58.421492Z",
+                    "watched_at": "2024-09-13T10:50:58.421Z",
                     "rating": null
                 },
                 {
@@ -267,7 +267,7 @@ export const house_usher_continuing = {
                     "number": 3,
                     "special": false,
                     "is_watched": true,
-                    "watched_at": "2024-09-13T10:50:58.78649Z",
+                    "watched_at": "2024-09-13T10:50:58.786Z",
                     "rating": 8
                 },
                 {

--- a/src/core/api/episodeWatches.ts
+++ b/src/core/api/episodeWatches.ts
@@ -1,4 +1,5 @@
 import { paginatedRequest, Resource } from '../http';
+import { normalizeWatchedAt } from '../utils/normalizeWatchedAt';
 import type { ProgressCallback } from '../utils/ProgressReporter';
 
 type EpisodeWatchEntry = {
@@ -29,5 +30,5 @@ export async function fetchAllEpisodeWatches(
         (entry) => entry.episode_id,
     );
 
-    return new Map(entries.map(e => [e.episode_id, e.watched_at ?? null]));
+    return new Map(entries.map(e => [e.episode_id, normalizeWatchedAt(e.watched_at)]));
 }

--- a/src/core/api/favoriteList.ts
+++ b/src/core/api/favoriteList.ts
@@ -44,6 +44,7 @@ export async function favoriteList({
 
         const info = await getMovie({
             id: movie.uuid,
+            userId,
             imdbResolver,
         });
         liberatedMovies.push({
@@ -58,6 +59,7 @@ export async function favoriteList({
         progress.report(show.name);
         const info = await getShow({
             id: show.uuid,
+            userId,
             imdbResolver,
             onProgress: ({ value: { current, previous }, message }) => {
                 progress.increment(current - previous);

--- a/src/core/api/followedMovies.ts
+++ b/src/core/api/followedMovies.ts
@@ -3,6 +3,7 @@ import type { Movie } from '../types/Movie';
 import { assertDefined } from '../utils/assertDefined';
 import { ProgressCallback, ProgressReporter } from '../utils/ProgressReporter';
 import type { MovieEntry } from './models/MovieEntry';
+import { getMovieRating } from './ratings';
 import { toIMDB } from './toIMDB';
 
 type FollowedMoviesOptions = {
@@ -15,6 +16,9 @@ type FollowedMoviesOptions = {
  * Retrieves a list of followed movies.
  * @returns {Array} An array of movie objects.
  */
+const MOVIE_INCREMENT = .5;
+const RATING_INCREMENT = .5;
+
 export async function followedMovies({
     userId,
     imdbResolver = toIMDB,
@@ -45,8 +49,11 @@ export async function followedMovies({
 
         const imdb = await imdbResolver({ id: parseInt(tvdb), type: 'movie' });
 
-        progress.increment(1);
+        progress.increment(MOVIE_INCREMENT);
         progress.report(title);
+
+        const rating = await getMovieRating(movie.uuid, userId);
+        progress.increment(RATING_INCREMENT);
 
         liberatedMovies.push({
             id: {
@@ -58,6 +65,7 @@ export async function followedMovies({
             title,
             watched_at: movie.watched_at,
             is_watched: movie.watched_at != null,
+            rating,
         });
     }
 

--- a/src/core/api/followedShows.ts
+++ b/src/core/api/followedShows.ts
@@ -76,8 +76,9 @@ export async function followedShows({
     for (const show of shows) {
         progress.report(show.title);
 
-        const info = await getShowSeasons({
+        const seasons = await getShowSeasons({
             id: show.id.tvdb,
+            userId,
             onProgress: ({ message, value: { previous, current } }) => {
                 progress.increment(SEASONS_INCREMENT * (current - previous));
                 progress.report(`${show.title} - ${message}`);
@@ -88,7 +89,7 @@ export async function followedShows({
 
         liberatedShows.push({
             ...show,
-            seasons: info,
+            seasons,
         });
     }
 

--- a/src/core/api/getMovie.ts
+++ b/src/core/api/getMovie.ts
@@ -2,15 +2,18 @@ import { request, Resource } from '../http';
 import { Movie } from '../types/Movie';
 import { assertDefined } from '../utils/assertDefined';
 import { MovieResponse } from './models/MovieResponse';
+import { getMovieRating } from './ratings';
 import { toIMDB } from './toIMDB';
 
 type GetMovieOptions = {
     id: string;
+    userId?: string;
     imdbResolver?: typeof toIMDB;
 }
 
 export async function getMovie({
     id,
+    userId,
     imdbResolver = toIMDB,
 }: GetMovieOptions): Promise<Omit<Movie, 'is_watched'>> {
     const movie = await request<MovieResponse>(Resource.Get.Movie.GetByUUID(id))
@@ -34,5 +37,6 @@ export async function getMovie({
         created_at: movie.created_at,
         uuid: movie.uuid,
         title: movie.name,
+        rating: userId != null ? await getMovieRating(movie.uuid, userId) : null,
     };
 }

--- a/src/core/api/getShow.ts
+++ b/src/core/api/getShow.ts
@@ -7,12 +7,14 @@ import { toIMDB } from './toIMDB';
 
 type GetSeriesOptions = {
     id: string;
+    userId?: string;
     imdbResolver?: typeof toIMDB;
     onProgress?: ProgressCallback;
 }
 
 export async function getShow({
     id,
+    userId,
     imdbResolver = toIMDB,
     onProgress = () => { },
 }: GetSeriesOptions): Promise<Omit<Show, 'created_at' | 'status'>> {
@@ -28,6 +30,7 @@ export async function getShow({
 
     const seasons = await getShowSeasons({
         id: tvdb,
+        userId,
         imdbResolver,
         onProgress,
     });

--- a/src/core/api/getShowSeasons.ts
+++ b/src/core/api/getShowSeasons.ts
@@ -2,10 +2,12 @@ import { request, Resource } from '../http';
 import type { Season } from '../types/Season';
 import { ProgressCallback, ProgressReporter } from '../utils/ProgressReporter';
 import type { ShowInfoResponse } from './models/ShowInfoResponse';
+import { getEpisodeRating } from './ratings';
 import { toIMDB } from './toIMDB';
 
 type SeriesInfoOptions = {
     id: number;
+    userId?: string;
     imdbResolver?: typeof toIMDB;
     onProgress?: ProgressCallback;
     /**
@@ -18,6 +20,7 @@ type SeriesInfoOptions = {
 
 export async function getShowSeasons({
     id,
+    userId,
     imdbResolver = toIMDB,
     onProgress = () => { },
     watchedAtMap,
@@ -42,6 +45,10 @@ export async function getShowSeasons({
                 ? (watchedAtMap.get(episode.id) ?? null)
                 : (await request<{ watched_date: string }>(Resource.Get.Episode.Info(episode.id))).watched_date;
 
+            const rating = userId != null
+                ? await getEpisodeRating(episode.id, userId)
+                : null;
+
             const extendedEpisode = {
                 id: {
                     tvdb: episode.id,
@@ -51,6 +58,7 @@ export async function getShowSeasons({
                 special: episode.is_special,
                 is_watched: episode.is_watched,
                 watched_at,
+                rating,
             };
 
             progress.increment(1);

--- a/src/core/api/getShowSeasons.ts
+++ b/src/core/api/getShowSeasons.ts
@@ -1,6 +1,8 @@
 import { request, Resource } from '../http';
 import type { Season } from '../types/Season';
+import { normalizeWatchedAt } from '../utils/normalizeWatchedAt';
 import { ProgressCallback, ProgressReporter } from '../utils/ProgressReporter';
+import { fetchAllEpisodeWatches } from './episodeWatches';
 import type { ShowInfoResponse } from './models/ShowInfoResponse';
 import { getEpisodeRating } from './ratings';
 import { toIMDB } from './toIMDB';
@@ -29,6 +31,9 @@ export async function getShowSeasons({
 
     const { seasons = [] } = await request<ShowInfoResponse>(url);
 
+    const resolvedWatchedAtMap = watchedAtMap
+        ?? (userId != null ? await fetchAllEpisodeWatches(userId) : undefined);
+
     const progress = new ProgressReporter(
         seasons.reduce((acc, season) => acc + season.episodes.length, 0),
         onProgress,
@@ -41,9 +46,9 @@ export async function getShowSeasons({
         for (let j = 0; j < season.episodes.length; j++) {
             const episode = season.episodes[j];
 
-            const watched_at = watchedAtMap
-                ? (watchedAtMap.get(episode.id) ?? null)
-                : (await request<{ watched_date: string }>(Resource.Get.Episode.Info(episode.id))).watched_date;
+            const watched_at = resolvedWatchedAtMap
+                ? (resolvedWatchedAtMap.get(episode.id) ?? null)
+                : normalizeWatchedAt((await request<{ watched_date: string }>(Resource.Get.Episode.Info(episode.id))).watched_date);
 
             const rating = userId != null
                 ? await getEpisodeRating(episode.id, userId)

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,4 +1,5 @@
 export * from './episodeWatches';
+export * from './ratings';
 export * from './favoriteList';
 export * from './followedMovies';
 export * from './followedShows';

--- a/src/core/api/models/ShowInfoResponse.ts
+++ b/src/core/api/models/ShowInfoResponse.ts
@@ -3,18 +3,19 @@ export interface ShowInfoResponse {
     id: number;
     name: string;
   }
-  
+
   interface Season {
     id: string;
     number: number;
     episode_watched_count: number;
     episodes: Episode[];
   }
-  
+
   interface Episode {
     is_watched: boolean;
     id: number;
     number: number;
     is_special: boolean;
+    rating?: number | null;
   }
   

--- a/src/core/api/myLists.ts
+++ b/src/core/api/myLists.ts
@@ -55,6 +55,7 @@ export async function myLists({
             if (item.type === MediaType.Show) {
                 const info = await getShow({
                     id: item.uuid,
+                    userId,
                     imdbResolver,
                     onProgress: ({ value: { current, previous }, message }) => {
                         progress.increment(current - previous);
@@ -71,6 +72,7 @@ export async function myLists({
             if (item.type === MediaType.Movie) {
                 const info = await getMovie({
                     id: item.uuid,
+                    userId,
                     imdbResolver,
                 });
 

--- a/src/core/api/ratings.ts
+++ b/src/core/api/ratings.ts
@@ -1,0 +1,61 @@
+import { request, Resource } from '../http';
+
+type RatingSetResponse = {
+    data: {
+        set: string;
+        order: string;
+    };
+};
+
+type RatingVotesResponse = {
+    data: {
+        user_votes: Array<{ rating_id: number }>;
+    };
+};
+
+let ratingMappingPromise: Promise<Map<number, number>> | null = null;
+
+/**
+ * Fetches the TV Time star rating set once and returns a map from rating_id
+ * to the equivalent Trakt-compatible 1-10 score (TV Time uses a 1-5 star
+ * scale, doubled here for parity with Trakt's CSV import).
+ */
+export function getRatingMapping(): Promise<Map<number, number>> {
+    if (ratingMappingPromise == null) {
+        ratingMappingPromise = request<RatingSetResponse>(Resource.Get.Ratings.Set)
+            .then(({ data: { order } }) => {
+                const ids = order.split(',').map(id => parseInt(id, 10));
+                return new Map(ids.map((id, index) => [id, (index + 1) * 2]));
+            })
+            .catch(() => new Map<number, number>());
+    }
+
+    return ratingMappingPromise;
+}
+
+async function resolveRating(url: string): Promise<number | null> {
+    const mapping = await getRatingMapping();
+    if (mapping.size === 0) {
+        return null;
+    }
+
+    try {
+        const response = await request<RatingVotesResponse>(url);
+        const vote = response.data?.user_votes?.[0];
+        if (vote == null) {
+            return null;
+        }
+
+        return mapping.get(vote.rating_id) ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export function getMovieRating(movieUuid: string, userId: string): Promise<number | null> {
+    return resolveRating(Resource.Get.Ratings.Movie(movieUuid, userId));
+}
+
+export function getEpisodeRating(episodeId: number, userId: string): Promise<number | null> {
+    return resolveRating(Resource.Get.Ratings.Episode(episodeId, userId));
+}

--- a/src/core/http/Resource.ts
+++ b/src/core/http/Resource.ts
@@ -59,6 +59,20 @@ export const Resource = {
             Movies: (userId: string, page = 1) => `https://app.tvtime.com/sidecar?o=https://msapi.tvtime.com/prod/v1/tracking/cgw/follows/user/${userId}&entity_type=movie&sort=watched_date,desc&page=${page}&page_limit=500`,
         },
         EpisodeWatches: (userId: string, page = 1) => `https://app.tvtime.com/sidecar?o=https://msapi.tvtime.com/prod/v1/tracking/watches/user/${userId}&entity_type=episode&page=${page}&page_limit=500`,
+        Ratings: {
+            /**
+             * The URL to fetch the rating set definition (rating_id → star position mapping).
+             */
+            Set: 'https://app.tvtime.com/sidecar?o=https://msapi.tvtime.com/live/v1/ratings/sets/stars_wording_scalev2',
+            /**
+             * The URL to fetch a single user's rating for a movie.
+             */
+            Movie: (movieUuid: string, userId: string) => `https://app.tvtime.com/sidecar?o=https://msapi.tvtime.com/live/v1/ratings/votes/${movieUuid}/${userId}&set=stars_wording_scalev2`,
+            /**
+             * The URL to fetch a single user's rating for an episode.
+             */
+            Episode: (episodeId: number, userId: string) => `https://app.tvtime.com/sidecar?o=https://msapi.tvtime.com/prod/v1/ratings/votes/episode/${episodeId}/${userId}&set=stars_wording_scalev2`,
+        },
         Movie: {
             GetByUUID: (uuid: string) => `https://app.tvtime.com/sidecar?o=https://msapi.tvtime.com/prod/v1/movies/${uuid}`,
         },

--- a/src/core/serializer/toCsv.test.ts
+++ b/src/core/serializer/toCsv.test.ts
@@ -21,10 +21,10 @@ describe("toCsv", () => {
             "imdb_id,tvdb_id,type,title,season,episode,is_special,is_watched,watched_at,status,is_watchlisted,rating\r",
         );
         expect(nobody).toBe(
-            `${mr_nobody_watched.id?.imdb},${mr_nobody_watched.id?.tvdb},movie,${mr_nobody_watched.title},,,false,${mr_nobody_watched.is_watched},${mr_nobody_watched.watched_at},,false,\r`,
+            `${mr_nobody_watched.id?.imdb},${mr_nobody_watched.id?.tvdb},movie,${mr_nobody_watched.title},,,false,${mr_nobody_watched.is_watched},${mr_nobody_watched.watched_at},,false,${mr_nobody_watched.rating ?? ""}\r`,
         );
         expect(matrix).toBe(
-            `${the_matrix_not_watched.id?.imdb},${the_matrix_not_watched.id?.tvdb},movie,${the_matrix_not_watched.title},,,false,${the_matrix_not_watched.is_watched},,,true,\r`,
+            `${the_matrix_not_watched.id?.imdb},${the_matrix_not_watched.id?.tvdb},movie,${the_matrix_not_watched.title},,,false,${the_matrix_not_watched.is_watched},,,true,${the_matrix_not_watched.rating ?? ""}\r`,
         );
     });
 
@@ -53,6 +53,7 @@ describe("toCsv", () => {
                                 number: episode,
                                 is_watched,
                                 watched_at,
+                                rating,
                             },
                         ) => {
                             if (!is_watched) {
@@ -60,7 +61,7 @@ describe("toCsv", () => {
                             }
                             const row = rest.shift();
                             expect(row).toBe(
-                                `${id?.imdb},${id?.tvdb},episode,${chernobyl_up_to_date.title},${season},${episode},${special},${is_watched},${watched_at},${chernobyl_up_to_date.status},false,\r`,
+                                `${id?.imdb},${id?.tvdb},episode,${chernobyl_up_to_date.title},${season},${episode},${special},${is_watched},${watched_at},${chernobyl_up_to_date.status},false,${rating ?? ""}\r`,
                             );
                         },
                     );
@@ -77,6 +78,7 @@ describe("toCsv", () => {
                                 number: episode,
                                 is_watched,
                                 watched_at,
+                                rating,
                             },
                         ) => {
                             if (!is_watched) {
@@ -86,7 +88,7 @@ describe("toCsv", () => {
                             expect(row).toBe(
                                 `${id?.imdb},${id?.tvdb},episode,${house_usher_continuing.title},${season},${episode},${special},${is_watched},${
                                     watched_at ?? ""
-                                },${house_usher_continuing.status},${watched_at == null},\r`,
+                                },${house_usher_continuing.status},${watched_at == null},${rating ?? ""}\r`,
                             );
                         },
                     );

--- a/src/core/serializer/toCsv.test.ts
+++ b/src/core/serializer/toCsv.test.ts
@@ -18,13 +18,13 @@ describe("toCsv", () => {
         const [header, nobody, matrix] = result.split("\n");
 
         expect(header).toBe(
-            "imdb_id,tvdb_id,type,title,season,episode,is_special,is_watched,watched_at,status,is_watchlisted\r",
+            "imdb_id,tvdb_id,type,title,season,episode,is_special,is_watched,watched_at,status,is_watchlisted,rating\r",
         );
         expect(nobody).toBe(
-            `${mr_nobody_watched.id?.imdb},${mr_nobody_watched.id?.tvdb},movie,${mr_nobody_watched.title},,,false,${mr_nobody_watched.is_watched},${mr_nobody_watched.watched_at},,false\r`,
+            `${mr_nobody_watched.id?.imdb},${mr_nobody_watched.id?.tvdb},movie,${mr_nobody_watched.title},,,false,${mr_nobody_watched.is_watched},${mr_nobody_watched.watched_at},,false,\r`,
         );
         expect(matrix).toBe(
-            `${the_matrix_not_watched.id?.imdb},${the_matrix_not_watched.id?.tvdb},movie,${the_matrix_not_watched.title},,,false,${the_matrix_not_watched.is_watched},,,true\r`,
+            `${the_matrix_not_watched.id?.imdb},${the_matrix_not_watched.id?.tvdb},movie,${the_matrix_not_watched.title},,,false,${the_matrix_not_watched.is_watched},,,true,\r`,
         );
     });
 
@@ -39,7 +39,7 @@ describe("toCsv", () => {
         expect(result).toBeString();
         const [header, ...rest] = result.split("\n");
         expect(header).toBe(
-            "imdb_id,tvdb_id,type,title,season,episode,is_special,is_watched,watched_at,status,is_watchlisted\r",
+            "imdb_id,tvdb_id,type,title,season,episode,is_special,is_watched,watched_at,status,is_watchlisted,rating\r",
         );
 
         chernobyl_up_to_date.seasons
@@ -60,7 +60,7 @@ describe("toCsv", () => {
                             }
                             const row = rest.shift();
                             expect(row).toBe(
-                                `${id?.imdb},${id?.tvdb},episode,${chernobyl_up_to_date.title},${season},${episode},${special},${is_watched},${watched_at},${chernobyl_up_to_date.status},false\r`,
+                                `${id?.imdb},${id?.tvdb},episode,${chernobyl_up_to_date.title},${season},${episode},${special},${is_watched},${watched_at},${chernobyl_up_to_date.status},false,\r`,
                             );
                         },
                     );
@@ -86,7 +86,7 @@ describe("toCsv", () => {
                             expect(row).toBe(
                                 `${id?.imdb},${id?.tvdb},episode,${house_usher_continuing.title},${season},${episode},${special},${is_watched},${
                                     watched_at ?? ""
-                                },${house_usher_continuing.status},${watched_at == null}\r`,
+                                },${house_usher_continuing.status},${watched_at == null},\r`,
                             );
                         },
                     );
@@ -104,7 +104,7 @@ describe("toCsv", () => {
 
             const row = rest.shift();
             expect(row).toBe(
-                `${id?.imdb},${id?.tvdb},show,${title},,,,,,${status},${hasUnwatchedEpisode}\r`,
+                `${id?.imdb},${id?.tvdb},show,${title},,,,,,${status},${hasUnwatchedEpisode},\r`,
             );
         })
     });

--- a/src/core/serializer/toCsv.ts
+++ b/src/core/serializer/toCsv.ts
@@ -14,6 +14,7 @@ const header = [
     "watched_at",
     "status",
     "is_watchlisted",
+    "rating",
 ];
 
 type CsvParams = {
@@ -30,6 +31,7 @@ export function toCsv({
             title,
             is_watched,
             watched_at,
+            rating,
         }) => [
             id?.imdb,
             id?.tvdb,
@@ -42,6 +44,7 @@ export function toCsv({
             watched_at,
             "",
             watched_at == null,
+            rating ?? "",
         ]);
 
     const episodesCsvEntries = shows
@@ -62,6 +65,7 @@ export function toCsv({
                         number: episode,
                         is_watched,
                         watched_at,
+                        rating,
                     }) => [
                         id?.imdb,
                         id?.tvdb,
@@ -74,6 +78,7 @@ export function toCsv({
                         watched_at,
                         status,
                         watched_at == null,
+                        rating ?? "",
                     ])
             )
         );
@@ -101,6 +106,7 @@ export function toCsv({
                 "",
                 status,
                 hasUnwatchedEpisode,
+                "",
             ]]
         });
 

--- a/src/core/types/Movie.ts
+++ b/src/core/types/Movie.ts
@@ -6,4 +6,5 @@ export type Movie = {
     uuid: string;
     title: string;
     created_at: string;
+    rating: number | null;
 } & WatchInfo;

--- a/src/core/types/Season.ts
+++ b/src/core/types/Season.ts
@@ -7,5 +7,6 @@ export type Season = {
         number: number;
         special: boolean;
         id: MediaIdentifier;
+        rating: number | null;
     } & WatchInfo>;
 };

--- a/src/core/utils/normalizeWatchedAt.ts
+++ b/src/core/utils/normalizeWatchedAt.ts
@@ -1,0 +1,20 @@
+/**
+ * TV Time returns `watched_at` in two formats depending on the endpoint:
+ *  - bulk watches:       `2024-09-13T10:50:29.147929Z` (ISO with microseconds)
+ *  - per-episode info:   `2024-09-13 10:50:49`        (space separated, no TZ)
+ *
+ * This normalizer collapses both to a millisecond-precision ISO string so
+ * downstream consumers (CSV, JSON, fixtures) only need to deal with one form.
+ */
+export function normalizeWatchedAt(value: string | null | undefined): string | null {
+    if (value == null) {
+        return null;
+    }
+
+    const date = new Date(value.includes('T') ? value : value.replace(' ', 'T') + 'Z');
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date.toISOString();
+}


### PR DESCRIPTION
## Summary
- Adds `rating` field to `Movie` and `Episode` types, surfaced as a new column in `activity_history.csv`.
- Resolves user ratings via TV Time's per-item endpoints:
  - `live/v1/ratings/votes/{movie_uuid}/{user_id}?set=stars_wording_scalev2`
  - `prod/v1/ratings/votes/episode/{episode_id}/{user_id}?set=stars_wording_scalev2`
- Fetches the `stars_wording_scalev2` set once and maps `rating_id` -> 1-10 (TV Time's 1-5 stars doubled for Trakt CSV import compatibility).

## Notes
- Per-item only; TV Time exposes no bulk endpoint. The `setCache` layer absorbs the cost on re-runs.
- `user_votes` empty -> `rating: null`.
- Movie meta does not carry a personal rating; speculative `meta.rating` / `data.rating` model fields are not introduced.
- Show level rating intentionally not exposed (TV Time does not support personal show ratings).

## Test plan
- [x] Run CLI export, confirm `activity_history.csv` has `rating` column populated for rated movies and episodes.
- [x] Build extension (`bun run extension:build`), liberate from the browser, confirm ratings appear in the exported CSV.
- [x] Spot-check a known movie rating and a known episode rating against the TV Time UI.